### PR TITLE
Type children classes of DescriptorMatcher

### DIFF
--- a/src/types/opencv/BFMatcher.ts
+++ b/src/types/opencv/BFMatcher.ts
@@ -1,4 +1,4 @@
-import { bool, int, Ptr } from "./_types";
+import { bool, DescriptorMatcher, int, Ptr } from "./_types";
 
 /**
  * For each descriptor in the first set, this matcher finds the closest descriptor in the second set by
@@ -8,7 +8,7 @@ import { bool, int, Ptr } from "./_types";
  * [opencv2/features2d.hpp](https://github.com/opencv/opencv/tree/master/modules/core/include/opencv2/features2d.hpp#L1140).
  *
  */
-export declare class BFMatcher {
+export declare class BFMatcher extends DescriptorMatcher {
   public constructor(normType?: int, crossCheck?: bool);
 
   /**

--- a/src/types/opencv/DescriptorMatcher.ts
+++ b/src/types/opencv/DescriptorMatcher.ts
@@ -1,4 +1,5 @@
 import {
+  Algorithm,
   bool,
   FileNode,
   FileStorage,
@@ -18,7 +19,7 @@ import {
  * [opencv2/features2d.hpp](https://github.com/opencv/opencv/tree/master/modules/core/include/opencv2/features2d.hpp#L860).
  *
  */
-export declare class DescriptorMatcher {
+export declare class DescriptorMatcher extends Algorithm {
   /**
    *   If the collection is not empty, the new descriptors are added to existing train descriptors.
    *

--- a/src/types/opencv/FlannBasedMatcher.ts
+++ b/src/types/opencv/FlannBasedMatcher.ts
@@ -1,4 +1,4 @@
-import { bool, FileNode, FileStorage, InputArrayOfArrays, Ptr } from "./_types";
+import { bool, DescriptorMatcher, FileNode, FileStorage, InputArrayOfArrays, Ptr } from "./_types";
 
 /**
  * This matcher trains [cv::flann::Index](#d1/db2/classcv_1_1flann_1_1Index}) on a train descriptor
@@ -12,7 +12,7 @@ import { bool, FileNode, FileStorage, InputArrayOfArrays, Ptr } from "./_types";
  * [opencv2/features2d.hpp](https://github.com/opencv/opencv/tree/master/modules/core/include/opencv2/features2d.hpp#L1187).
  *
  */
-export declare class FlannBasedMatcher {
+export declare class FlannBasedMatcher extends DescriptorMatcher {
   public constructor(indexParams?: Ptr, searchParams?: Ptr);
 
   /**


### PR DESCRIPTION
See the documentation: https://docs.opencv.org/4.x/d3/da1/classcv_1_1BFMatcher.html

BFMatcher has methods like `match` inherited from DescriptorMatcher. Same for `FlannBasedMatcher`.

Not sure how these typings are created, don't hesitate to point me to the source.