### PR TITLE
Correct TypeScript signature for `minEnclosingCircle` to match opencv.js single parameter

### DIFF
--- a/src/types/opencv/_hacks.ts
+++ b/src/types/opencv/_hacks.ts
@@ -32,6 +32,12 @@ export declare class Point {
   public y: number;
 }
 
+export declare class Circle {
+  public constructor(center: Point, radius: number);
+  public center: Point;
+  public radius: number;
+}
+
 export declare class Size {
   public constructor(width: number, height: number);
   public width: number;

--- a/src/types/opencv/imgproc_shape.ts
+++ b/src/types/opencv/imgproc_shape.ts
@@ -1,5 +1,6 @@
 import {
   bool,
+  Circle,
   double,
   float,
   InputArray,
@@ -12,6 +13,7 @@ import {
   Rect,
   RotatedRect,
 } from "./_types";
+
 /*
  * # Structural Analysis and Shape Descriptors
  *
@@ -530,16 +532,10 @@ export declare function minAreaRect(points: InputArray): RotatedRect;
  * The function finds the minimal enclosing circle of a 2D point set using an iterative algorithm.
  *
  * @param points Input vector of 2D points, stored in std::vector<> or Mat
- *
- * @param center Output center of the circle.
- *
- * @param radius Output radius of the circle.
  */
 export declare function minEnclosingCircle(
   points: InputArray,
-  center: any,
-  radius: any,
-): void;
+): Circle;
 
 /**
  * The function finds a triangle of minimum area enclosing the given set of 2D points and returns its


### PR DESCRIPTION
This pull request corrects the TypeScript definition of the `minEnclosingCircle` function to align with the opencv.js implementation, which accepts only a single parameter. The existing type definitions mistakenly required three parameters to be passed to this function, which conflicted with the actual opencv.js API and led to compile-time errors in TypeScript projects.

The erroneous type signature forced TypeScript developers to call `minEnclosingCircle` incorrectly with three arguments or to suppress type checking with a `@ts-ignore` comment, neither of which is an ideal solution.

To address this issue, I have updated the function signature in the TypeScript definitions to accept only one parameter, as per the opencv.js documentation. Additionally, I have introduced a new `Circle` class definition that encapsulates the return type of `minEnclosingCircle`, providing a structured object that contains both the `center` point and `radius` of the circle.

The `Circle` class enhances type safety and developer experience by offering clear insights into the expected return object structure, which includes:

- `center`: The center point of the enclosing circle.
- `radius`: The radius of the enclosing circle.

By merging this pull request, we will ensure that the TypeScript definitions correctly represent the opencv.js library's API, thus preventing any confusion and errors when developers invoke `minEnclosingCircle`. This change will also promote better code quality and maintainability in TypeScript projects leveraging opencv.js.
