### PR TITLE
Complement Mat class and BackgroundSubtractorMOG2 declaration

### DIFF
--- a/src/types/opencv/Mat.ts
+++ b/src/types/opencv/Mat.ts
@@ -1600,12 +1600,38 @@ export declare class Mat extends EmscriptenEmbindInstance {
   public shortPtr(i: any, j: any): any;
   public ushortPtr(i: any, j: any): any;
   public intPtr(i: any, j: any): any;
-  public ucharAt(i: any): any;
-  public charAt(i: any): any;
   public floatPtr(i: any, j: any): any;
-  public doubleAt(i: int, j: int): any;
   public doublePtr(i: any, j: any): any;
   public intPtr(i: any, j: any): any;
+
+  public charAt(i0: number): number;
+  public charAt(i0: number, i1: number): number;
+  public charAt(i0: number, i1: number, i2: number): number;
+
+  public ucharAt(i0: number): number;
+  public ucharAt(i0: number, i1: number): number;
+  public ucharAt(i0: number, i1: number, i2: number): number;
+
+  public shortAt(i0: number): number;
+  public shortAt(i0: number, i1: number): number;
+  public shortAt(i0: number, i1: number, i2: number): number;
+
+  public ushortAt(i0: number): number;
+  public ushortAt(i0: number, i1: number): number;
+  public ushortAt(i0: number, i1: number, i2: number): number;
+
+  public intAt(i0: number): number;
+  public intAt(i0: number, i1: number): number;
+  public intAt(i0: number, i1: number, i2: number): number;
+
+  public floatAt(i0: number): number;
+  public floatAt(i0: number, i1: number): number;
+  public floatAt(i0: number, i1: number, i2: number): number;
+
+  public doubleAt(i0: number): number;
+  public doubleAt(i0: number, i1: number): number;
+  public doubleAt(i0: number, i1: number, i2: number): number;
+
   public setTo(value: Mat | Scalar, mask?: Mat): Mat;
   /**
    * Sometimes, you will have to play with certain region of images.

--- a/src/types/opencv/_types.ts
+++ b/src/types/opencv/_types.ts
@@ -42,6 +42,7 @@ export * from "./RotatedRect";
 export * from "./softdouble";
 export * from "./softfloat";
 export * from "./video_track";
+export * from "./video_background_segm";
 export * from "./_hacks";
 export * from "./Tracker";
 export * from "./TrackerMIL";

--- a/src/types/opencv/imgproc_filter.ts
+++ b/src/types/opencv/imgproc_filter.ts
@@ -529,7 +529,7 @@ export declare function morphologyDefaultBorderValue(): Scalar;
 export declare function morphologyEx(
   src: InputArray,
   dst: OutputArray,
-  op: int,
+  op: int | MorphTypes,
   kernel: InputArray,
   anchor?: Point,
   iterations?: int,


### PR DESCRIPTION
Add existing functions on Mat class.
Add declare class of BackgroundSubtractorMOG2.
Complement morphologyEx function.

All changes have been tested.